### PR TITLE
Upgrade OpenAI to latest Bicep schema

### DIFF
--- a/infra/core/ai/cognitiveservices.bicep
+++ b/infra/core/ai/cognitiveservices.bicep
@@ -1,7 +1,7 @@
 param name string
 param location string = resourceGroup().location
 param tags object = {}
-@description('The custom subdomain name used to access the API. Defaults to the value of the name parameter.')
+
 param customSubDomainName string = name
 param deployments array = []
 param kind string = 'OpenAI'
@@ -10,7 +10,7 @@ param sku object = {
   name: 'S0'
 }
 
-resource account 'Microsoft.CognitiveServices/accounts@2022-10-01' = {
+resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: name
   location: location
   tags: tags
@@ -23,13 +23,16 @@ resource account 'Microsoft.CognitiveServices/accounts@2022-10-01' = {
 }
 
 @batchSize(1)
-resource deployment 'Microsoft.CognitiveServices/accounts/deployments@2022-10-01' = [for deployment in deployments: {
+resource deployment 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01' = [for deployment in deployments: {
   parent: account
   name: deployment.name
   properties: {
     model: deployment.model
     raiPolicyName: contains(deployment, 'raiPolicyName') ? deployment.raiPolicyName : null
-    scaleSettings: deployment.scaleSettings
+  }
+  sku: {
+    name: 'Standard'
+    capacity: deployment.capacity
   }
 }]
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,6 +18,7 @@ param openAiResourceName string = ''
 param openAiResourceGroupName string = ''
 param openAiResourceGroupLocation string = ''
 param openAiSkuName string = ''
+param openAiDeploymentCapacity int = 30
 
 var resourceToken = toLower(uniqueString(subscription().id, name, location))
 var tags = { 'azd-env-name': name }
@@ -53,9 +54,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
           name: 'gpt-35-turbo'
           version: '0301'
         }
-        scaleSettings: {
-          scaleType: 'Standard'
-        }
+        capacity: openAiDeploymentCapacity
       }
     ]
   }


### PR DESCRIPTION
## Purpose

This PR updates the Bicep to use the 2023-05-01 resource version, which sets capacity correctly in the new quota system. Inspired by https://github.com/Azure-Samples/azure-search-openai-demo/pull/322/files

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run azd up
* Don't see quota error message!
* Check quotas, see 30K for each of the models