### PR TITLE
Infrastructure updates: 0301 to 0613

### DIFF
--- a/infra/core/ai/cognitiveservices.bicep
+++ b/infra/core/ai/cognitiveservices.bicep
@@ -30,9 +30,9 @@ resource deployment 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01
     model: deployment.model
     raiPolicyName: contains(deployment, 'raiPolicyName') ? deployment.raiPolicyName : null
   }
-  sku: {
+  sku: contains(deployment, 'sku') ? deployment.sku : {
     name: 'Standard'
-    capacity: deployment.capacity
+    capacity: 20
   }
 }]
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -55,9 +55,12 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         model: {
           format: 'OpenAI'
           name: 'gpt-35-turbo'
-          version: '0301'
+          version: '0613'
         }
-        capacity: openAiDeploymentCapacity
+        sku: {
+          name: 'Standard'
+          capacity: 30
+        }
       }
     ]
   }


### PR DESCRIPTION
## Purpose

Azure OpenAI isn't allowing new deployments of 3.5-turbo version 0301, it gives error "DeploymentModelNotSupported: Creating account deployment is not supported by the model 'gpt-35-turbo'. This is usually because there are better models available for the similar functionality." The error goes away when I update the version to 0613. T

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* azd up