### PR TITLE
Update invalid product slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ languages:
 products:
 - azure
 - azure-container-apps
-- azure-openai-service
+- azure-openai
 - azure-container-registry
 page_type: sample
 urlFragment: openai-chat-app-quickstart


### PR DESCRIPTION
According to [doc](https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies?branch=main#product), update invalid product slug `azure-openai-service` to `azure-openai`.

@hemarina, @pamelafox   for notification.