### PR TITLE
Fix broken image paths in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,11 +46,11 @@ since the local app needs credentials for Azure OpenAI to work properly.
 * A basic HTML/JS frontend that streams responses from the backend using [JSON Lines](http://jsonlines.org/) over a [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 * [Bicep files](https://docs.microsoft.com/azure/azure-resource-manager/bicep/) for provisioning Azure resources, including Azure OpenAI, Azure Container Apps, Azure Container Registry, Azure Log Analytics, and RBAC roles.
 
-![Screenshot of the chat app](docs/screenshot_chatapp.png)
+![Screenshot of the chat app](screenshot_chatapp.png)
 
 ## Architecture diagram
 
-![Architecture diagram: Azure Container Apps inside Container Apps Environment, connected to Container Registry with Container, connected to Managed Identity for Azure OpenAI](readme_diagram.png)
+![Architecture diagram: Azure Container Apps inside Container Apps Environment, connected to Container Registry with Container, connected to Managed Identity for Azure OpenAI](../readme_diagram.png)
 
 ## Getting started
 


### PR DESCRIPTION
## Purpose
* Fix two broken image links in `docs/README.md`. The screenshot and the architecture diagram were referenced with paths relative to the repository root instead of to the `docs/` folder, so both render as broken images when `docs/README.md` is viewed. This corrects the relative paths so they resolve to the actual image locations: `screenshot_chatapp.png` (same folder) and `../readme_diagram.png` (repository root).

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
This is a documentation-only change. To verify, open `docs/README.md` in GitHub's rendered view on the PR branch and confirm the chat-app screenshot and the architecture diagram both display, with no broken-image icons. No build, install, or local checkout is required.

## What to Check
Verify that the following are valid
* The chat-app screenshot renders in `docs/README.md`.
* The architecture diagram renders in `docs/README.md`.
* No other content in the file is changed; only the two image paths.

## Other Information
* Documentation only. No code, API, or behavior changes. The image files themselves are untouched; only the link paths in `docs/README.md` are corrected.